### PR TITLE
Use domReady instead of ready

### DIFF
--- a/core-label.html
+++ b/core-label.html
@@ -76,7 +76,7 @@ All taps on the `core-label` will be forwarded to the "target" element.
           generate(this);
           this._forElement = null;
         },
-        ready: function() {
+        domReady: function() {
           if (!this.for) {
             this._forElement = this.querySelector('[for]');
             this._tie();


### PR DESCRIPTION
Light DOM children are guaranteed to exist at `domReady`, not `ready`.
